### PR TITLE
Add ts-node as a dependancy

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -15,7 +15,7 @@ requiredEnvVariables.forEach((variable) => {
 });
 module.exports = {
   scripts: {
-    describe: "nodemon --watch functions --exec ts-node server/describe.ts",
+    describe: "nodemon --watch functions --exec yarn ts-node server/describe.ts",
     service: "ts-node server/service.ts",
     studio: "react-scripts start",
     start: npsUtils.concurrent.nps("describe", "service", "studio"),

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "xstate": "^4.38.2"
   },
   "devDependencies": {
+    "ts-node": "^10.9.1",
     "modularscale-sass": "^3.0.10",
     "nodemon": "^3.0.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
Heyo, 

Neat little tool, was actually considering building something similar.

I think you may have ts-node installed globally. While this is common, I didn't only dev machine.
I added it as a dev dependancy and modified the package script to call it via yarn (instead of via path, as some may not have it there)

P.S. Amazing trick using jsDocs to build the function description. 
