### PR TITLE
Update typescript JSDoc format

### DIFF
--- a/functions/getWeather.ts
+++ b/functions/getWeather.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 
 /**
- * @property {number} lat Latitude of the city.
- * @property {number} lon Longitude of the city.
+ * lat: Latitude of the city
+ * lon: Longitude of the city
  */
 interface SymphonyRequest {
   lat: number;
@@ -10,8 +10,8 @@ interface SymphonyRequest {
 }
 
 /**
- * @property {string} temperature The temperature of the city.
- * @property {string} unit The unit of the temperature.
+ * temperature: The temperature of the city
+ * unit: The unit of the temperature
  */
 interface SymphonyResponse {
   temperature: number;
@@ -19,7 +19,7 @@ interface SymphonyResponse {
 }
 
 /**
- * @description Gets temperature of a city.
+ * Gets temperature of a city
  */
 export default async function handler(
   request: SymphonyRequest

--- a/functions/kelvinToCelsius.ts
+++ b/functions/kelvinToCelsius.ts
@@ -1,26 +1,26 @@
 /**
- * @property {number} number Number in Kelvin.
+ * value: Value in Kelvin
  */
 interface SymphonyRequest {
-  number: number;
+  value: number;
 }
 
 /**
- * @property {number} temperature Number in Celsius.
+ * temperature: Value in Celsius
  */
 interface SymphonyResponse {
-  number: number;
+  value: number;
 }
 
 /**
- * @description Converts Kelvin to Celsius.
+ * Converts Kelvin to Celsius
  */
 export default async function handler(
   request: SymphonyRequest
 ): Promise<SymphonyResponse> {
-  const { number } = request;
+  const { value } = request;
 
   return {
-    number: Math.round(number - 273.15),
+    value: Math.round(value - 273.15),
   };
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "xstate": "^4.38.2"
   },
   "devDependencies": {
-    "ts-node": "^10.9.1",
     "modularscale-sass": "^3.0.10",
     "nodemon": "^3.0.1",
+    "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "eslintConfig": {

--- a/server/python/describe.py
+++ b/server/python/describe.py
@@ -21,17 +21,16 @@ def generate_function_description(name, function: Callable[..., Any], request_mo
     response_schema = response_model.model_json_schema()
 
     remove_title(request_schema)
-    remove_title(response_schema)
+    # remove_title(response_schema)
 
-    # Reorder the fields so that 'type' comes first
     request_schema = {'type': request_schema['type'], **request_schema}
-    response_schema = {'type': response_schema['type'], **response_schema}
+    # response_schema = {'type': response_schema['type'], **response_schema}
 
     function_description = {
         "name": name,
         "description": function.__doc__.strip(),
         "parameters": request_schema,
-        "returns": response_schema,
+        # "returns": response_schema,
     }
 
     return function_description

--- a/server/python/descriptions.json
+++ b/server/python/descriptions.json
@@ -30,24 +30,6 @@
                 "matrix1",
                 "matrix2"
             ]
-        },
-        "returns": {
-            "type": "object",
-            "properties": {
-                "result": {
-                    "description": "The result of the matrix multiplication",
-                    "items": {
-                        "items": {
-                            "type": "number"
-                        },
-                        "type": "array"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "result"
-            ]
         }
     },
     {
@@ -56,19 +38,6 @@
         "parameters": {
             "type": "object",
             "properties": {}
-        },
-        "returns": {
-            "type": "object",
-            "properties": {
-                "facts": {
-                    "description": "A list of dog facts",
-                    "items": {},
-                    "type": "array"
-                }
-            },
-            "required": [
-                "facts"
-            ]
         }
     },
     {
@@ -84,23 +53,6 @@
             },
             "required": [
                 "ipAddress"
-            ]
-        },
-        "returns": {
-            "type": "object",
-            "properties": {
-                "lat": {
-                    "description": "The latitude of IP address",
-                    "type": "number"
-                },
-                "lng": {
-                    "description": "The longitude of IP address",
-                    "type": "number"
-                }
-            },
-            "required": [
-                "lat",
-                "lng"
             ]
         }
     }

--- a/server/typescript/descriptions.json
+++ b/server/typescript/descriptions.json
@@ -1,17 +1,17 @@
 [
   {
     "name": "getWeather-ts",
-    "description": "Gets temperature of a city.",
+    "description": "Gets temperature of a city",
     "parameters": {
       "type": "object",
       "properties": {
         "lat": {
           "type": "number",
-          "description": "Latitude of the city."
+          "description": "Latitude of the city"
         },
         "lon": {
           "type": "number",
-          "description": "Longitude of the city."
+          "description": "Longitude of the city"
         }
       },
       "required": [
@@ -22,17 +22,17 @@
   },
   {
     "name": "kelvinToCelsius-ts",
-    "description": "Converts Kelvin to Celsius.",
+    "description": "Converts Kelvin to Celsius",
     "parameters": {
       "type": "object",
       "properties": {
-        "number": {
+        "value": {
           "type": "number",
-          "description": "Number in Kelvin."
+          "description": "Value in Kelvin"
         }
       },
       "required": [
-        "number"
+        "value"
       ]
     }
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -110,7 +110,7 @@ body {
           border-radius: ms(-8);
 
           &.user {
-            background: $orange;
+            background: $red;
           }
         }
 
@@ -127,7 +127,7 @@ body {
           font-family: "DM Mono", monospace;
           font-size: ms(-1);
           color: $neutral-500;
-          width: calc(100vw - #{ms(0) * 2});
+          width: calc(100vw - #{ms(0) * 2} - 21px - #{ms(-4)});
           overflow-x: scroll;
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5405,6 +5405,11 @@ internal-slot@^1.0.5:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+io-ts@^2.2.20:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.20.tgz#be42b75f6668a2c44f706f72ee6e4c906777c7f5"
+  integrity sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"


### PR DESCRIPTION
Updated JSDoc format to avoid defining types twice.

old:
```typescript
/**
 * @property {value} number Value in Kelvin.
 */
interface SymphonyRequest {
  value: number;
}
```

new:
```typescript
/**
 * value: Value in Kelvin
 */
interface SymphonyRequest {
  value: number;
}
```