### PR TITLE
fix: Add pgcrypto for gen_random_uuid

### DIFF
--- a/symphony/database/setup.sh
+++ b/symphony/database/setup.sh
@@ -19,6 +19,9 @@ fi
 # Create database
 psql -h $DB_HOST -p $DB_PORT -c "CREATE DATABASE $DB_NAME;"
 
+# Add pgcrypto extension to the database
+psql -h $DB_HOST -p $DB_PORT -d $DB_NAME -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
+
 # Create role
 psql -h $DB_HOST -p $DB_PORT -c "CREATE ROLE $DB_ROLE nologin;"
 


### PR DESCRIPTION
Hey, I ran into an issue with "ERROR: function gen_random_uuid() does not exist." 

Added pgcrypto to the database/setup.sh script to sort it out. Could be useful for others. Thoughts?