### PR TITLE
Describe const arrow functions in functions

### DIFF
--- a/symphony/server/typescript/describe.ts
+++ b/symphony/server/typescript/describe.ts
@@ -57,6 +57,13 @@ function getSchema(propertyType) {
   }
 }
 
+function hasConstArrowFunction(node: ts.Node) {
+  if (ts.isArrowFunction(node) && ts.isVariableDeclaration(node.parent)) {
+    return true;
+  }
+  return node.getChildren().some((child) => hasConstArrowFunction(child));
+}
+
 function extractParameters(node: ts.InterfaceDeclaration) {
   const parameters: Parameters = {
     type: "object",
@@ -119,7 +126,10 @@ function generateSchema(sourceFile: ts.SourceFile, fileName: string) {
       }
     }
 
-    if (ts.isFunctionDeclaration(node)) {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      (ts.isVariableStatement(node) && hasConstArrowFunction(node))
+    ) {
       const jsDocComments = ts.getJSDocCommentsAndTags(node);
 
       for (const comment of jsDocComments) {

--- a/symphony/server/typescript/descriptions.json
+++ b/symphony/server/typescript/descriptions.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "getWeather-ts",
-    "description": "",
+    "description": "Gets temperature of a city",
     "parameters": {
       "type": "object",
       "properties": {
@@ -39,7 +39,7 @@
   },
   {
     "name": "kelvinToCelsius-ts",
-    "description": "",
+    "description": "Converts Kelvin to Celsius",
     "parameters": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Some of the TypeScript functions included declare in the form `const handler = () => {}`, which isn't matched by the describe.ts TS parser; this fixes that, so their JSDoc descriptions are properly picked up and passed into the JSON function specification